### PR TITLE
Add rules for v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.2.0
+
+- Add [`lines_longer_than_80_chars`](https://dart-lang.github.io/linter/lints/lines_longer_than_80_chars.html), see [#13](https://github.com/tenhobi/effective_dart/issues/13)
+- Add [`implementation_imports`](https://dart-lang.github.io/linter/lints/implementation_imports.html), see [#14](https://github.com/tenhobi/effective_dart/issues/14)
+- Add [`prefer_relative_imports`](https://dart-lang.github.io/linter/lints/prefer_relative_imports.html), see [#15](https://github.com/tenhobi/effective_dart/issues/15)
+- Add [`camel_case_extensions`](https://dart-lang.github.io/linter/lints/camel_case_extensions.html), see [#16](https://github.com/tenhobi/effective_dart/issues/16)
+- Add [`avoid_catching_errors`](https://dart-lang.github.io/linter/lints/avoid_catching_errors.html), see [#17](https://github.com/tenhobi/effective_dart/issues/17)
+- Add [`prefer_mixin`](https://dart-lang.github.io/linter/lints/prefer_mixin.html), see [#18](https://github.com/tenhobi/effective_dart/issues/18)
+- Add [`avoid_types_on_closure_parameters`](https://dart-lang.github.io/linter/lints/avoid_types_on_closure_parameters.html), see [#19](https://github.com/tenhobi/effective_dart/issues/19)
+- Add [`avoid_equals_and_hash_code_on_mutable_classes`](https://dart-lang.github.io/linter/lints/avoid_equals_and_hash_code_on_mutable_classes.html), see [#20](https://github.com/tenhobi/effective_dart/issues/20)
+
 ## 1.1.2
 
 - Documentation updated with a chapter about consider lints.
@@ -7,7 +18,7 @@
 
 ## 1.1.0
 
-- Disable `comment_references` because it is way too restrictive ([see this issue](https://github.com/dart-lang/sdk/issues/36974))
+- Disable [`comment_references`](https://dart-lang.github.io/linter/lints/comment_references.html) because it is way too restrictive ([see this issue](https://github.com/dart-lang/sdk/issues/36974))
 
 ## 1.0.1
 
@@ -16,4 +27,4 @@
 
 ## 1.0.0
 
-- Add linst according to current state of the Effective Dart `analysis_options.yaml`.
+- Add linst according to the current state of the Effective Dart `analysis_options.yaml`.

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 [![pub package](https://img.shields.io/pub/v/effective_dart.svg)](https://pub.dartlang.org/packages/effective_dart)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-This package provides lints that attempt to comply with all [*Effective Dart*](https://dart.dev/guides/language/effective-dart) guide rules.
-
 **Be consistent. Be brief.**
 
-> *Note*: This package is inspired by the [pedantic](https://github.com/dart-lang/pedantic) package, which contains lints internally used at Google.
+This package provides lints that attempt to comply with all [*Effective Dart*](https://dart.dev/guides/language/effective-dart) guide rules.
 
 You can easily see all enabled rules on the [Supported Lint Rules](http://dart-lang.github.io/linter/lints/) site.
+
+*Note*: This package is inspired by the [pedantic](https://github.com/dart-lang/pedantic) package, which contains lints internally used at Google.
 
 ## Using the Lints
 
@@ -54,7 +54,7 @@ Following lints have been considered and will not be enforced by this package:
 
 There are situations when you want to suppress a specific lint rule. You can suppress lints alone in your project on multiple levels. We will go through examples of how to suppress [`public_member_api_docs`](https://dart-lang.github.io/linter/lints/public_member_api_docs.html) lint rule.
 
-> **Note**: this package tries to comply with all [*Effective Dart*](https://dart.dev/guides/language/effective-dart) guide rules. That means we generally do not want to disable a rule in this package if it works properly. Yet, if you think some rule should be disabled by this package, open an issue.
+**Note**: this package tries to comply with all [*Effective Dart*](https://dart.dev/guides/language/effective-dart) guide rules. That means we generally do not want to disable a rule in this package if it works properly. Yet, if you think some rule should be disabled by this package, open an issue.
 
 ### Line Level
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Or, if you using e.g. continuous builds, they will likely fail whenever a new ve
 include: package:effective_dart/analysis_options.1.1.0.yaml
 ```
 
-## Consider lints
+## Consider Lints
 
 Consider guidelines are practices that you might or might not want to follow, depending on circumstances, precedents, and your own preference.
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,13 @@
 
 [![pub package](https://img.shields.io/pub/v/effective_dart.svg)](https://pub.dartlang.org/packages/effective_dart)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![style: effective dart](https://img.shields.io/badge/style-effective_dart-40c4ff.svg)](https://github.com/tenhobi/effective_dart)
 
 **Be consistent. Be brief.**
 
-This package provides lints that attempt to comply with all [*Effective Dart*](https://dart.dev/guides/language/effective-dart) guide rules.
+This package provides lints that attempt to comply with all [*Effective Dart*](https://dart.dev/guides/language/effective-dart) guide rules. You can easily see all enabled rules on the [Supported Lint Rules](http://dart-lang.github.io/linter/lints/) site.
 
-You can easily see all enabled rules on the [Supported Lint Rules](http://dart-lang.github.io/linter/lints/) site.
-
-*Note*: This package is inspired by the [pedantic](https://github.com/dart-lang/pedantic) package, which contains lints internally used at Google.
+**Note**: This package is inspired by the [pedantic](https://github.com/dart-lang/pedantic) package, which contains lints internally used at Google.
 
 ## Using the Lints
 
@@ -46,7 +45,6 @@ Following lints are not enforced by this package:
 
 Following lints have been considered and will not be enforced by this package:
 
-- [`lines_longer_than_80_chars`](https://dart-lang.github.io/linter/lints/lines_longer_than_80_chars.html) might be practical not to follow for many people
 - [`unnecessary_getters`](https://dart-lang.github.io/linter/lints/unnecessary_getters.html) has been [disabled](https://github.com/dart-lang/linter/issues/23)
 - [`comment_references`](https://dart-lang.github.io/linter/lints/comment_references.html) is way too restrictive and comment references are handled in different ways in tools ([see this issue](https://github.com/dart-lang/sdk/issues/36974))
 

--- a/lib/analysis_options.1.2.0.yaml
+++ b/lib/analysis_options.1.2.0.yaml
@@ -2,14 +2,14 @@ linter:
   rules:
     # STYLE
     - camel_case_types
-    - camel_case_extensions
+    - camel_case_extensions # TODO
     - library_names
     - file_names
     - library_prefixes
     - non_constant_identifier_names
     - constant_identifier_names # prefer
     - directives_ordering
-    - lines_longer_than_80_chars # avoid
+    - lines_longer_than_80_chars # avoid # TODO
     - curly_braces_in_flow_control_structures
 
     # DOCUMENTATION
@@ -19,9 +19,9 @@ linter:
     #- comment_references # Unused because https://github.com/dart-lang/sdk/issues/36974
 
     # USAGE
-    - implementation_imports
+    - implementation_imports # TODO
     - avoid_relative_lib_imports # prefer
-    - prefer_relative_imports # prefer
+    - prefer_relative_imports # prefer # TODO
     - prefer_adjacent_string_concatenation
     - prefer_interpolation_to_compose_strings # prefer
     - unnecessary_brace_in_string_interps # avoid
@@ -42,14 +42,14 @@ linter:
     - unnecessary_new
     - unnecessary_const
     - avoid_catches_without_on_clauses # avoid
-    - avoid_catching_errors
+    - avoid_catching_errors # TODO
     - use_rethrow_when_possible
 
     # DESIGN
     - use_to_and_as_if_applicable # prefer
     - one_member_abstracts # avoid
     - avoid_classes_with_only_static_members # avoid
-    - prefer_mixin
+    - prefer_mixin # TODO
     - prefer_final_fields # prefer
     - use_setters_to_change_properties
     - avoid_setters_without_getters
@@ -58,12 +58,12 @@ linter:
     - type_annotate_public_apis # prefer
     #- prefer_typing_uninitialized_variables # consider
     - omit_local_variable_types # avoid
-    - avoid_types_on_closure_parameters # avoid
+    - avoid_types_on_closure_parameters # avoid # TODO
     - avoid_return_types_on_setters # avoid
     - prefer_generic_function_type_aliases
     - avoid_private_typedef_functions # prefer
     #- use_function_type_syntax_for_parameters # consider
     - avoid_positional_boolean_parameters # avoid
     - hash_and_equals
-    - avoid_equals_and_hash_code_on_mutable_classes # avoid
+    - avoid_equals_and_hash_code_on_mutable_classes # avoid # TODO
     - avoid_null_checks_in_equality_operators

--- a/lib/analysis_options.1.2.0.yaml
+++ b/lib/analysis_options.1.2.0.yaml
@@ -1,0 +1,69 @@
+linter:
+  rules:
+    # STYLE
+    - camel_case_types
+    - camel_case_extensions
+    - library_names
+    - file_names
+    - library_prefixes
+    - non_constant_identifier_names
+    - constant_identifier_names # prefer
+    - directives_ordering
+    - lines_longer_than_80_chars # avoid
+    - curly_braces_in_flow_control_structures
+
+    # DOCUMENTATION
+    - slash_for_doc_comments
+    - package_api_docs # prefer
+    - public_member_api_docs # prefer
+    #- comment_references # Unused because https://github.com/dart-lang/sdk/issues/36974
+
+    # USAGE
+    - implementation_imports
+    - avoid_relative_lib_imports # prefer
+    - prefer_relative_imports # prefer
+    - prefer_adjacent_string_concatenation
+    - prefer_interpolation_to_compose_strings # prefer
+    - unnecessary_brace_in_string_interps # avoid
+    - prefer_collection_literals
+    - avoid_function_literals_in_foreach_calls # avoid
+    - prefer_iterable_whereType
+    - prefer_function_declarations_over_variables
+    - unnecessary_lambdas
+    - prefer_equal_for_default_values
+    - avoid_init_to_null
+    - unnecessary_getters_setters
+    #- unnecessary_getters # prefer # Disabled pending fix: https://github.com/dart-lang/linter/issues/23
+    #- prefer_expression_function_bodies # consider
+    - unnecessary_this
+    - prefer_initializing_formals
+    - type_init_formals
+    - empty_constructor_bodies
+    - unnecessary_new
+    - unnecessary_const
+    - avoid_catches_without_on_clauses # avoid
+    - avoid_catching_errors
+    - use_rethrow_when_possible
+
+    # DESIGN
+    - use_to_and_as_if_applicable # prefer
+    - one_member_abstracts # avoid
+    - avoid_classes_with_only_static_members # avoid
+    - prefer_mixin
+    - prefer_final_fields # prefer
+    - use_setters_to_change_properties
+    - avoid_setters_without_getters
+    - avoid_returning_null # avoid
+    - avoid_returning_this # avoid
+    - type_annotate_public_apis # prefer
+    #- prefer_typing_uninitialized_variables # consider
+    - omit_local_variable_types # avoid
+    - avoid_types_on_closure_parameters # avoid
+    - avoid_return_types_on_setters # avoid
+    - prefer_generic_function_type_aliases
+    - avoid_private_typedef_functions # prefer
+    #- use_function_type_syntax_for_parameters # consider
+    - avoid_positional_boolean_parameters # avoid
+    - hash_and_equals
+    - avoid_equals_and_hash_code_on_mutable_classes # avoid
+    - avoid_null_checks_in_equality_operators

--- a/lib/analysis_options.1.2.0.yaml
+++ b/lib/analysis_options.1.2.0.yaml
@@ -2,14 +2,14 @@ linter:
   rules:
     # STYLE
     - camel_case_types
-    - camel_case_extensions # TODO
+    - camel_case_extensions
     - library_names
     - file_names
     - library_prefixes
     - non_constant_identifier_names
     - constant_identifier_names # prefer
     - directives_ordering
-    - lines_longer_than_80_chars # avoid # TODO
+    - lines_longer_than_80_chars # avoid
     - curly_braces_in_flow_control_structures
 
     # DOCUMENTATION
@@ -19,9 +19,9 @@ linter:
     #- comment_references # Unused because https://github.com/dart-lang/sdk/issues/36974
 
     # USAGE
-    - implementation_imports # TODO
+    - implementation_imports
     - avoid_relative_lib_imports # prefer
-    - prefer_relative_imports # prefer # TODO
+    - prefer_relative_imports # prefer
     - prefer_adjacent_string_concatenation
     - prefer_interpolation_to_compose_strings # prefer
     - unnecessary_brace_in_string_interps # avoid
@@ -42,14 +42,14 @@ linter:
     - unnecessary_new
     - unnecessary_const
     - avoid_catches_without_on_clauses # avoid
-    - avoid_catching_errors # TODO
+    - avoid_catching_errors
     - use_rethrow_when_possible
 
     # DESIGN
     - use_to_and_as_if_applicable # prefer
     - one_member_abstracts # avoid
     - avoid_classes_with_only_static_members # avoid
-    - prefer_mixin # TODO
+    - prefer_mixin
     - prefer_final_fields # prefer
     - use_setters_to_change_properties
     - avoid_setters_without_getters
@@ -58,12 +58,12 @@ linter:
     - type_annotate_public_apis # prefer
     #- prefer_typing_uninitialized_variables # consider
     - omit_local_variable_types # avoid
-    - avoid_types_on_closure_parameters # avoid # TODO
+    - avoid_types_on_closure_parameters # avoid
     - avoid_return_types_on_setters # avoid
     - prefer_generic_function_type_aliases
     - avoid_private_typedef_functions # prefer
     #- use_function_type_syntax_for_parameters # consider
     - avoid_positional_boolean_parameters # avoid
     - hash_and_equals
-    - avoid_equals_and_hash_code_on_mutable_classes # avoid # TODO
+    - avoid_equals_and_hash_code_on_mutable_classes # avoid
     - avoid_null_checks_in_equality_operators

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:effective_dart/analysis_options.1.1.0.yaml
+include: package:effective_dart/analysis_options.1.2.0.yaml

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: effective_dart
-description: This package provides the lints according to the Effective Dart guide.
-version: 1.1.2
+description: The set of rules corresponding to the Effective Dart guide.
+version: 1.2.0
 author: Honza Bittner <git@tenhobi.cz>
 repository: https://github.com/tenhobi/effective_dart
 issue_tracker: https://github.com/tenhobi/effective_dart/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,4 +7,4 @@ issue_tracker: https://github.com/tenhobi/effective_dart/issues
 homepage: https://github.com/tenhobi/effective_dart
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: '>=2.0.0 <3.0.0'


### PR DESCRIPTION
After going throgh Effective Dart guide, I have proposed adding a few (in my opinion) missed rules reference. I am awaiting adding them to the guide. 

Changes:

- Add [`lines_longer_than_80_chars`](https://dart-lang.github.io/linter/lints/lines_longer_than_80_chars.html)
- Add [`implementation_imports`](https://dart-lang.github.io/linter/lints/implementation_imports.html)
- Add [`prefer_relative_imports`](https://dart-lang.github.io/linter/lints/prefer_relative_imports.html)
- Add [`camel_case_extensions`](https://dart-lang.github.io/linter/lints/camel_case_extensions.html)
- Add [`avoid_catching_errors`](https://dart-lang.github.io/linter/lints/avoid_catching_errors.html)
- Add [`prefer_mixin`](https://dart-lang.github.io/linter/lints/prefer_mixin.html)
- Add [`avoid_types_on_closure_parameters`](https://dart-lang.github.io/linter/lints/avoid_types_on_closure_parameters.html)
- Add [`avoid_equals_and_hash_code_on_mutable_classes`](https://dart-lang.github.io/linter/lints/avoid_equals_and_hash_code_on_mutable_classes.html)


Fixes #13 
Fixes #14  
Fixes #15 
Fixes #16 
Fixes #17 
Fixes #18 
Fixes #19 
Fixes #20 