### PR TITLE
Improve docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,38 @@
 # Changelog
 
+This project adheres to [Semantic Versioning](http://semver.org).
+
+## 1.2.1
+
+- Applied [Semantic Line Breaks](https://sembr.org)
+- Changed description pursuant to [Analysis options](<https://dart.dev/guides/language/analysis-options#effective-dart-rules>) site
+- Fixed too short description ([#22](https://github.com/tenhobi/effective_dart/issues/22))
+
 ## 1.2.0
 
-- Add [`lines_longer_than_80_chars`](https://dart-lang.github.io/linter/lints/lines_longer_than_80_chars.html), see [#13](https://github.com/tenhobi/effective_dart/issues/13)
-- Add [`implementation_imports`](https://dart-lang.github.io/linter/lints/implementation_imports.html), see [#14](https://github.com/tenhobi/effective_dart/issues/14)
-- Add [`prefer_relative_imports`](https://dart-lang.github.io/linter/lints/prefer_relative_imports.html), see [#15](https://github.com/tenhobi/effective_dart/issues/15)
-- Add [`camel_case_extensions`](https://dart-lang.github.io/linter/lints/camel_case_extensions.html), see [#16](https://github.com/tenhobi/effective_dart/issues/16)
-- Add [`avoid_catching_errors`](https://dart-lang.github.io/linter/lints/avoid_catching_errors.html), see [#17](https://github.com/tenhobi/effective_dart/issues/17)
-- Add [`prefer_mixin`](https://dart-lang.github.io/linter/lints/prefer_mixin.html), see [#18](https://github.com/tenhobi/effective_dart/issues/18)
-- Add [`avoid_types_on_closure_parameters`](https://dart-lang.github.io/linter/lints/avoid_types_on_closure_parameters.html), see [#19](https://github.com/tenhobi/effective_dart/issues/19)
-- Add [`avoid_equals_and_hash_code_on_mutable_classes`](https://dart-lang.github.io/linter/lints/avoid_equals_and_hash_code_on_mutable_classes.html), see [#20](https://github.com/tenhobi/effective_dart/issues/20)
+- Added rule [`lines_longer_than_80_chars`](https://dart-lang.github.io/linter/lints/lines_longer_than_80_chars.html) ([#13](https://github.com/tenhobi/effective_dart/issues/13))
+- Added rule [`implementation_imports`](https://dart-lang.github.io/linter/lints/implementation_imports.html) ([#14](https://github.com/tenhobi/effective_dart/issues/14))
+- Added rule [`prefer_relative_imports`](https://dart-lang.github.io/linter/lints/prefer_relative_imports.html) ([#15](https://github.com/tenhobi/effective_dart/issues/15))
+- Added rule [`camel_case_extensions`](https://dart-lang.github.io/linter/lints/camel_case_extensions.html) ([#16](https://github.com/tenhobi/effective_dart/issues/16)
+- Added rule [`avoid_catching_errors`](https://dart-lang.github.io/linter/lints/avoid_catching_errors.html) ([#17](https://github.com/tenhobi/effective_dart/issues/17))
+- Added rule [`prefer_mixin`](https://dart-lang.github.io/linter/lints/prefer_mixin.html) ([#18](https://github.com/tenhobi/effective_dart/issues/18))
+- Added rule [`avoid_types_on_closure_parameters`](https://dart-lang.github.io/linter/lints/avoid_types_on_closure_parameters.html) ([#19](https://github.com/tenhobi/effective_dart/issues/19))
+- Added rule [`avoid_equals_and_hash_code_on_mutable_classes`](https://dart-lang.github.io/linter/lints/avoid_equals_and_hash_code_on_mutable_classes.html) ([#20](https://github.com/tenhobi/effective_dart/issues/20))
 
 ## 1.1.2
 
-- Documentation updated with a chapter about consider lints.
-- Add links to lints mentioned in README.
+- Updated documentation with a chapter about consider lints
+- Added links to lints mentioned in README
 
 ## 1.1.0
 
-- Disable [`comment_references`](https://dart-lang.github.io/linter/lints/comment_references.html) because it is way too restrictive ([see this issue](https://github.com/dart-lang/sdk/issues/36974))
+- Disabled [`comment_references`](https://dart-lang.github.io/linter/lints/comment_references.html) because it is way too restrictive ([see this issue](https://github.com/dart-lang/sdk/issues/36974))
 
 ## 1.0.1
 
-- Fix SDK version.
-- Enhance README.
+- Fixed SDK version
+- Enhanced README
 
 ## 1.0.0
 
-- Add linst according to the current state of the Effective Dart `analysis_options.yaml`.
+- Added linst according to the current state of the Effective Dart `analysis_options.yaml`

--- a/README.md
+++ b/README.md
@@ -2,13 +2,16 @@
 
 [![pub package](https://img.shields.io/pub/v/effective_dart.svg)](https://pub.dartlang.org/packages/effective_dart)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![style: effective dart](https://img.shields.io/badge/style-effective_dart-40c4ff.svg)](https://github.com/tenhobi/effective_dart)
+[![style: effective dart][badge]](https://github.com/tenhobi/effective_dart)
 
 **Be consistent. Be brief.**
 
-This package provides lints that attempt to comply with all [*Effective Dart*](https://dart.dev/guides/language/effective-dart) guide rules. You can easily see all enabled rules on the [Supported Lint Rules](http://dart-lang.github.io/linter/lints/) site.
+This package provides linter rules corresponding to the guidelines in
+*[Effective Dart][]*.
+You can easily see all enabled rules on the [Supported Lint Rules][] site.
 
-**Note**: This package is inspired by the [pedantic](https://github.com/dart-lang/pedantic) package, which contains lints internally used at Google.
+**Note**: This package is inspired by the [pedantic][] package,
+which contains lints internally used at Google.
 
 ## Using the Lints
 
@@ -25,7 +28,10 @@ Then add an include in your `analysis_options.yaml` file:
 include: package:effective_dart/analysis_options.yaml
 ```
 
-Or, if you using e.g. continuous builds, they will likely fail whenever a new version of `package:effective_dart` is released. To avoid this, specify a version of `analysis_options.yaml`:
+Or, if you using e.g. continuous builds,
+they will likely fail whenever a new version of `package:effective_dart`
+is released.
+To avoid this, specify a version of `analysis_options.yaml`:
 
 ```yaml
 include: package:effective_dart/analysis_options.1.2.0.yaml
@@ -33,7 +39,8 @@ include: package:effective_dart/analysis_options.1.2.0.yaml
 
 ## Consider Lints
 
-Consider guidelines are practices that you might or might not want to follow, depending on circumstances, precedents, and your own preference.
+Consider guidelines are practices that you might or might not want to follow,
+depending on circumstances, precedents, and your own preference.
 
 Following lints are not enforced by this package:
 
@@ -45,18 +52,30 @@ Following lints are not enforced by this package:
 
 Following lints have been considered and will not be enforced by this package:
 
-- [`unnecessary_getters`](https://dart-lang.github.io/linter/lints/unnecessary_getters.html) has been [disabled](https://github.com/dart-lang/linter/issues/23)
-- [`comment_references`](https://dart-lang.github.io/linter/lints/comment_references.html) is way too restrictive and comment references are handled in different ways in tools ([see this issue](https://github.com/dart-lang/sdk/issues/36974))
+- [`unnecessary_getters`](https://dart-lang.github.io/linter/lints/unnecessary_getters.html)
+has been [disabled](https://github.com/dart-lang/linter/issues/23)
+- [`comment_references`](https://dart-lang.github.io/linter/lints/comment_references.html)
+is way too restrictive and comment references are handled in different ways
+in tools ([see this issue](https://github.com/dart-lang/sdk/issues/36974))
 
 ## Suppressing Lints
 
-There are situations when you want to suppress a specific lint rule. You can suppress lints alone in your project on multiple levels. We will go through examples of how to suppress [`public_member_api_docs`](https://dart-lang.github.io/linter/lints/public_member_api_docs.html) lint rule.
+There are situations when you want to suppress a specific lint rule.
+You can suppress lints alone in your project on multiple levels.
+We will go through examples of how to suppress
+[`public_member_api_docs`](https://dart-lang.github.io/linter/lints/public_member_api_docs.html)
+lint rule.
 
-**Note**: this package tries to comply with all [*Effective Dart*](https://dart.dev/guides/language/effective-dart) guide rules. That means we generally do not want to disable a rule in this package if it works properly. Yet, if you think some rule should be disabled by this package, open an issue.
+**Note**: this package provides linter rules corresponding to the guidelines
+in *[Effective Dart][]*.
+That means we generally do not want to disable a rule in this package
+if it works properly.
+Yet, if you think some rule should be disabled by this package, open an issue.
 
 ### Line Level
 
-To suppress a specific lint rule on a line of code, you can put an `ignore` comment above the line of code:
+To suppress a specific lint rule on a line of code,
+you can put an `ignore` comment above the line of code:
 
 ```dart
 // ignore: public_member_api_docs
@@ -65,7 +84,8 @@ class MyClass {}
 
 ### File Level
 
-To suppress a specific lint rule on a file, you can put an `ignore_for_file` comment to the file:
+To suppress a specific lint rule on a file,
+you can put an `ignore_for_file` comment to the file:
 
 ```dart
 // ignore_for_file: public_member_api_docs
@@ -77,7 +97,8 @@ class MySecondClass {}
 
 ### Project Level
 
-To suppress a specific lint rule on a project, you can modify your `analysis_options.yaml` file:
+To suppress a specific lint rule on a project,
+you can modify your `analysis_options.yaml` file:
 
 ```yaml
 include: package:effective_dart/analysis_options.yaml
@@ -89,12 +110,18 @@ linter:
 
 ## Badge
 
-Show the world you're following the *Effective Dart* guide → [![style: effective dart](https://img.shields.io/badge/style-effective_dart-40c4ff.svg)](https://github.com/tenhobi/effective_dart)
+Show the world you're following *Effective Dart* →
+[![style: effective dart][badge]](https://github.com/tenhobi/effective_dart)
 
 ```md
-[![style: effective dart](https://img.shields.io/badge/style-effective_dart-40c4ff.svg)](https://github.com/tenhobi/effective_dart)
+[![style: effective dart][https://img.shields.io/badge/style-effective_dart-40c4ff.svg]](https://github.com/tenhobi/effective_dart)
 ```
 
 ## License
 
 Licensed under the [MIT License](LICENSE).
+
+[Effective Dart]: https://dart.dev/guides/language/effective-dart
+[pedantic]: https://github.com/dart-lang/pedantic
+[Supported Lint Rules]: http://dart-lang.github.io/linter/lints
+[badge]: https://img.shields.io/badge/style-effective_dart-40c4ff.svg

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: effective_dart
-description: The set of rules corresponding to the Effective Dart guide.
-version: 1.2.0
+description: Linter rules corresponding to the guidelines in Effective Dart.
+version: 1.2.1
 author: Honza Bittner <git@tenhobi.cz>
 repository: https://github.com/tenhobi/effective_dart
 issue_tracker: https://github.com/tenhobi/effective_dart/issues


### PR DESCRIPTION
- Use Semantic Line Breaks (https://sembr.org)
- Change description pursuant to Dart site (https://dart.dev/guides/language/analysis-options#effective-dart-rules)
From `lints that attempt to comply with all Effective Dart guide rules` to `Linter rules corresponding to the guidelines in Effective Dart`
- version bump to 1.2.1

Fixes #22 