### PR TITLE
Simple generators

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Every request must be reviewed and accepted by:
+
+*	@tenhobi

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,5 +1,7 @@
 name: CI
 
+on: [push]
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,19 @@
+name: CI
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    container:
+      image:  google/dart:latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install dependencies
+        run: pub get
+      - name: Format
+        run: dartfmt -w .
+      - name: Analyze
+        run: dartanalyzer --fatal-infos --fatal-warnings .
+#      - name: Run tests
+#        run: pub run test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # effective_dart
 
+[![Actions status](https://github.com/tenhobi/effective_dart/workflows/CI/badge.svg)](https://github.com/tenhobi/effective_dart/actions)
 [![pub package](https://img.shields.io/pub/v/effective_dart.svg)](https://pub.dartlang.org/packages/effective_dart)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![style: effective dart][badge]](https://github.com/tenhobi/effective_dart)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ You can easily see all enabled rules on the [Supported Lint Rules][] site.
 **Note**: This package is inspired by the [pedantic][] package,
 which contains lints internally used at Google.
 
+This package also provides additional markup data for tools such us [Linter][].
+
 ## Using the Lints
 
 To use the lints add a dev dependency in your `pubspec.yaml`:
@@ -125,3 +127,4 @@ Licensed under the [MIT License](LICENSE).
 [pedantic]: https://github.com/dart-lang/pedantic
 [Supported Lint Rules]: http://dart-lang.github.io/linter/lints
 [badge]: https://img.shields.io/badge/style-effective_dart-40c4ff.svg
+[Linter]: https://github.com/dart-lang/linter

--- a/doc/metadata.md
+++ b/doc/metadata.md
@@ -1,0 +1,34 @@
+# Metadata Specs
+
+The document has a root `effective_dart`, which contains keys as rules (for example `camel_case_types`).
+
+Each rule has these attributes:
+
+- `guide` = `style` | `documentation` | `usage` | `design`
+- `severity` = `do` | `don't` | `prefer` | `avoid` | `consider`
+- `references` = `List<String>` with urls to given guideline
+- *optional* `disabled` = `false` (default) | `true`
+- *optional* `disabled_reason` = `String`, (used when `disabled` is `true`)
+
+**Note** that `consider` rules are not marked as disabled, but are commented out in `analysis_options` file.
+
+## Example
+
+```yaml
+effective_dart:
+  camel_case_types:
+    guide: style
+    severity: do
+    references:
+      - https://dart.dev/guides/language/effective-dart/style#do-name-types-using-uppercamelcase
+
+  comment_references:
+    guide: documentation
+    severity: do
+    references:
+      - https://dart.dev/guides/language/effective-dart/documentation#do-use-square-brackets-in-doc-comments-to-refer-to-in-scope-identifiers
+    disabled: true
+    disabled_reason: "Unused because https://github.com/dart-lang/sdk/issues/36974"
+
+  # ...
+```

--- a/lib/analysis_options.1.0.0.yaml
+++ b/lib/analysis_options.1.0.0.yaml
@@ -1,3 +1,4 @@
+# effective_dart version 1.0.0
 linter:
   rules:
     # STYLE

--- a/lib/analysis_options.1.1.0.yaml
+++ b/lib/analysis_options.1.1.0.yaml
@@ -1,3 +1,4 @@
+# effective_dart version 1.1.0
 linter:
   rules:
     # STYLE

--- a/lib/analysis_options.1.2.0.yaml
+++ b/lib/analysis_options.1.2.0.yaml
@@ -1,3 +1,4 @@
+# effective_dart version 1.2.0
 linter:
   rules:
     # STYLE

--- a/lib/analysis_options.1.3.0.yaml
+++ b/lib/analysis_options.1.3.0.yaml
@@ -68,3 +68,73 @@ linter:
     - hash_and_equals # do
     - prefer_final_fields # prefer
     - use_to_and_as_if_applicable # prefer
+
+analyzer:
+  errors:
+    # STYLE
+    camel_case_types: error
+    camel_case_extensions: error
+    library_names: error
+    file_names: error
+    library_prefixes: error
+    non_constant_identifier_names: error
+    constant_identifier_names: warning
+    directives_ordering: error
+    lines_longer_than_80_chars: warning
+    curly_braces_in_flow_control_structures: error
+
+    # DOCUMENTATION
+    slash_for_doc_comments: error
+    package_api_docs: warning
+    public_member_api_docs: warning
+    #comment_references: error
+
+    # USAGE
+    unnecessary_brace_in_string_interps: warning
+    #prefer_expression_function_bodies: info
+    prefer_relative_imports: warning
+    prefer_adjacent_string_concatenation: error
+    prefer_interpolation_to_compose_strings: warning
+    implementation_imports: error
+    prefer_collection_literals: error
+    avoid_function_literals_in_foreach_calls: warning
+    prefer_iterable_whereType: error
+    prefer_function_declarations_over_variables: error
+    unnecessary_lambdas: error
+    prefer_equal_for_default_values: error
+    avoid_init_to_null: error
+    unnecessary_getters_setters: error
+    #unnecessary_getters: warning
+    avoid_relative_lib_imports: warning
+    unnecessary_this: error
+    prefer_initializing_formals: error
+    type_init_formals: error
+    empty_constructor_bodies: error
+    unnecessary_new: error
+    unnecessary_const: error
+    avoid_catches_without_on_clauses: warning
+    avoid_catching_errors: error
+    use_rethrow_when_possible: error
+
+    # DESIGN
+    avoid_null_checks_in_equality_operators: error
+    one_member_abstracts: warning
+    avoid_classes_with_only_static_members: warning
+    prefer_mixin: error
+    avoid_equals_and_hash_code_on_mutable_classes: warning
+    use_setters_to_change_properties: error
+    avoid_setters_without_getters: error
+    avoid_returning_null: warning
+    avoid_returning_this: warning
+    type_annotate_public_apis: warning
+    #prefer_typing_uninitialized_variables: info
+    omit_local_variable_types: warning
+    avoid_types_on_closure_parameters: warning
+    avoid_return_types_on_setters: error
+    prefer_generic_function_type_aliases: error
+    avoid_private_typedef_functions: warning
+    #use_function_type_syntax_for_parameters: info
+    avoid_positional_boolean_parameters: warning
+    hash_and_equals: error
+    prefer_final_fields: warning
+    use_to_and_as_if_applicable: warning

--- a/lib/analysis_options.1.3.0.yaml
+++ b/lib/analysis_options.1.3.0.yaml
@@ -1,0 +1,14 @@
+# effective_dart version 1.3.0
+linter:
+  rules:
+    # STYLE
+    - camel_case_types # do
+    - camel_case_extensions # do
+    - library_names # do
+    - file_names # do
+    - library_prefixes # do
+    - non_constant_identifier_names # do
+    - constant_identifier_names # prefer
+    - directives_ordering # do
+    - lines_longer_than_80_chars # avoid
+    - curly_braces_in_flow_control_structures # do

--- a/lib/analysis_options.1.3.0.yaml
+++ b/lib/analysis_options.1.3.0.yaml
@@ -12,3 +12,59 @@ linter:
     - directives_ordering # do
     - lines_longer_than_80_chars # avoid
     - curly_braces_in_flow_control_structures # do
+
+    # DOCUMENTATION
+    - slash_for_doc_comments # do
+    - package_api_docs # prefer
+    - public_member_api_docs # prefer
+    #- comment_references # do # Unused because https://github.com/dart-lang/sdk/issues/36974
+
+    # USAGE
+    - unnecessary_brace_in_string_interps # avoid
+    #- prefer_expression_function_bodies # consider
+    - prefer_relative_imports # prefer
+    - prefer_adjacent_string_concatenation # do
+    - prefer_interpolation_to_compose_strings # prefer
+    - implementation_imports # don't
+    - prefer_collection_literals # do
+    - avoid_function_literals_in_foreach_calls # avoid
+    - prefer_iterable_whereType # do
+    - prefer_function_declarations_over_variables # do
+    - unnecessary_lambdas # don't
+    - prefer_equal_for_default_values # do
+    - avoid_init_to_null # don't
+    - unnecessary_getters_setters # don't
+    #- unnecessary_getters # prefer # Disabled pending fix: https://github.com/dart-lang/linter/issues/23
+    - avoid_relative_lib_imports # prefer
+    - unnecessary_this # don't
+    - prefer_initializing_formals # do
+    - type_init_formals # don't
+    - empty_constructor_bodies # do
+    - unnecessary_new # don't
+    - unnecessary_const # don't
+    - avoid_catches_without_on_clauses # avoid
+    - avoid_catching_errors # don't
+    - use_rethrow_when_possible # do
+
+    # DESIGN
+    - avoid_null_checks_in_equality_operators # don't
+    - one_member_abstracts # avoid
+    - avoid_classes_with_only_static_members # avoid
+    - prefer_mixin # do
+    - avoid_equals_and_hash_code_on_mutable_classes # avoid
+    - use_setters_to_change_properties # do
+    - avoid_setters_without_getters # don't
+    - avoid_returning_null # avoid
+    - avoid_returning_this # avoid
+    - type_annotate_public_apis # prefer
+    #- prefer_typing_uninitialized_variables # consider
+    - omit_local_variable_types # avoid
+    - avoid_types_on_closure_parameters # avoid
+    - avoid_return_types_on_setters # don't
+    - prefer_generic_function_type_aliases # don't
+    - avoid_private_typedef_functions # prefer
+    #- use_function_type_syntax_for_parameters # consider
+    - avoid_positional_boolean_parameters # avoid
+    - hash_and_equals # do
+    - prefer_final_fields # prefer
+    - use_to_and_as_if_applicable # prefer

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:effective_dart/analysis_options.1.2.0.yaml
+include: package:effective_dart/analysis_options.1.3.0.yaml

--- a/lib/metadata.1.3.0.yaml
+++ b/lib/metadata.1.3.0.yaml
@@ -54,3 +54,259 @@ effective_dart:
     severity: do
     references:
       - https://dart.dev/guides/language/effective-dart/style#do-use-curly-braces-for-all-flow-control-structures
+  slash_for_doc_comments:
+    guide: documentation
+    severity: do
+    references:
+      - https://dart.dev/guides/language/effective-dart/documentation#do-use--doc-comments-to-document-members-and-types
+  package_api_docs:
+    guide: documentation
+    severity: prefer
+    references:
+      - https://dart.dev/guides/language/effective-dart/documentation#prefer-writing-doc-comments-for-public-apis
+  public_member_api_docs:
+    guide: documentation
+    severity: prefer
+    references:
+      - https://dart.dev/guides/language/effective-dart/documentation#prefer-writing-doc-comments-for-public-apis
+  comment_references:
+    guide: documentation
+    severity: do
+    references:
+      - https://dart.dev/guides/language/effective-dart/documentation#do-use-square-brackets-in-doc-comments-to-refer-to-in-scope-identifiers
+    disabled: true
+    disabled_reason: "Unused because https://github.com/dart-lang/sdk/issues/36974"
+  unnecessary_brace_in_string_interps:
+    guide: usage
+    severity: avoid
+    references:
+      - https://dart.dev/guides/language/effective-dart/usage#avoid-using-curly-braces-in-interpolation-when-not-needed
+  prefer_expression_function_bodies:
+    guide: usage
+    severity: consider
+    references:
+      - https://dart.dev/guides/language/effective-dart/usage#consider-using--for-simple-members
+  prefer_relative_imports:
+    guide: usage
+    severity: prefer
+    references:
+      - https://dart.dev/guides/language/effective-dart/usage#prefer-relative-paths-when-importing-libraries-within-your-own-packages-lib-directory
+  prefer_adjacent_string_concatenation:
+    guide: usage
+    severity: do
+    references:
+      - https://dart.dev/guides/language/effective-dart/usage#do-use-adjacent-strings-to-concatenate-string-literals
+  prefer_interpolation_to_compose_strings:
+    guide: usage
+    severity: prefer
+    references:
+      - https://dart.dev/guides/language/effective-dart/usage#prefer-using-interpolation-to-compose-strings-and-values
+  implementation_imports:
+    guide: usage
+    severity: don't
+    references:
+      - https://dart.dev/guides/language/effective-dart/usage#dont-import-libraries-that-are-inside-the-src-directory-of-another-package
+  prefer_collection_literals:
+    guide: usage
+    severity: do
+    references:
+      - https://dart.dev/guides/language/effective-dart/usage#do-use-collection-literals-when-possible
+  avoid_function_literals_in_foreach_calls:
+    guide: usage
+    severity: avoid
+    references:
+      - https://dart.dev/guides/language/effective-dart/usage#avoid-using-iterableforeach-with-a-function-literal
+  prefer_iterable_whereType:
+    guide: usage
+    severity: do
+    references:
+      - https://dart.dev/guides/language/effective-dart/usage#do-use-wheretype-to-filter-a-collection-by-type
+  prefer_function_declarations_over_variables:
+    guide: usage
+    severity: do
+    references:
+      - https://dart.dev/guides/language/effective-dart/usage#do-use-a-function-declaration-to-bind-a-function-to-a-name
+  unnecessary_lambdas:
+    guide: usage
+    severity: don't
+    references:
+      - https://dart.dev/guides/language/effective-dart/usage#dont-create-a-lambda-when-a-tear-off-will-do
+  prefer_equal_for_default_values:
+    guide: usage
+    severity: do
+    references:
+      - https://dart.dev/guides/language/effective-dart/usage#do-use--to-separate-a-named-parameter-from-its-default-value
+  avoid_init_to_null:
+    guide: usage
+    severity: don't
+    references:
+      - https://dart.dev/guides/language/effective-dart/usage#dont-use-an-explicit-default-value-of-null
+  unnecessary_getters_setters:
+    guide: usage
+    severity: don't
+    references:
+      - https://dart.dev/guides/language/effective-dart/usage#dont-wrap-a-field-in-a-getter-and-setter-unnecessarily
+  unnecessary_getters:
+    guide: usage
+    severity: prefer
+    references:
+      - https://dart.dev/guides/language/effective-dart/usage#prefer-using-a-final-field-to-make-a-read-only-property
+    disabled: true
+    disabled_reason: "Disabled pending fix: https://github.com/dart-lang/linter/issues/23"
+  avoid_relative_lib_imports:
+    guide: usage
+    severity: prefer
+    references:
+      - https://dart.dev/guides/language/effective-dart/usage#prefer-relative-paths-when-importing-libraries-within-your-own-packages-lib-directory
+  unnecessary_this:
+    guide: usage
+    severity: don't
+    references:
+      - https://dart.dev/guides/language/effective-dart/usage#dont-use-this-when-not-needed-to-avoid-shadowing
+  prefer_initializing_formals:
+    guide: usage
+    severity: do
+    references:
+      - https://dart.dev/guides/language/effective-dart/usage#do-use-initializing-formals-when-possible
+  type_init_formals:
+    guide: usage
+    severity: don't
+    references:
+      - https://dart.dev/guides/language/effective-dart/usage#dont-type-annotate-initializing-formals
+  empty_constructor_bodies:
+    guide: usage
+    severity: do
+    references:
+      - https://dart.dev/guides/language/effective-dart/usage#do-use--instead-of--for-empty-constructor-bodies
+  unnecessary_new:
+    guide: usage
+    severity: don't
+    references:
+      - https://dart.dev/guides/language/effective-dart/usage#dont-use-new
+  unnecessary_const:
+    guide: usage
+    severity: don't
+    references:
+      - https://dart.dev/guides/language/effective-dart/usage#dont-use-const-redundantly
+  avoid_catches_without_on_clauses:
+    guide: usage
+    severity: avoid
+    references:
+      - https://dart.dev/guides/language/effective-dart/usage#avoid-catches-without-on-clauses
+  avoid_catching_errors:
+    guide: usage
+    severity: don't
+    references:
+      - https://dart.dev/guides/language/effective-dart/usage#dont-explicitly-catch-error-or-types-that-implement-it
+  use_rethrow_when_possible:
+    guide: usage
+    severity: do
+    references:
+      - https://dart.dev/guides/language/effective-dart/usage#do-use-rethrow-to-rethrow-a-caught-exception
+  avoid_null_checks_in_equality_operators:
+    guide: design
+    severity: don't
+    references:
+      - https://dart.dev/guides/language/effective-dart/design#dont-check-for-null-in-custom--operators
+  one_member_abstracts:
+    guide: design
+    severity: avoid
+    references:
+      - https://dart.dev/guides/language/effective-dart/design#avoid-defining-a-one-member-abstract-class-when-a-simple-function-will-do
+  avoid_classes_with_only_static_members:
+    guide: design
+    severity: avoid
+    references:
+      - https://dart.dev/guides/language/effective-dart/design#avoid-defining-a-class-that-contains-only-static-members
+  prefer_mixin:
+    guide: design
+    severity: do
+    references:
+      - https://dart.dev/guides/language/effective-dart/design#do-use-mixin-to-define-a-mixin-type
+      - https://dart.dev/guides/language/effective-dart/design#avoid-mixing-in-a-class-that-isnt-intended-to-be-a-mixin
+  avoid_equals_and_hash_code_on_mutable_classes:
+    guide: design
+    severity: avoid
+    references:
+      - https://dart.dev/guides/language/effective-dart/design#avoid-defining-custom-equality-for-mutable-classes
+  use_setters_to_change_properties:
+    guide: design
+    severity: do
+    references:
+      - https://dart.dev/guides/language/effective-dart/design#do-use-setters-for-operations-that-conceptually-change-properties
+  avoid_setters_without_getters:
+    guide: design
+    severity: don't
+    references:
+      - https://dart.dev/guides/language/effective-dart/design#dont-define-a-setter-without-a-corresponding-getter
+  avoid_returning_null:
+    guide: design
+    severity: avoid
+    references:
+      - https://dart.dev/guides/language/effective-dart/design#avoid-returning-null-from-members-whose-return-type-is-bool-double-int-or-num
+  avoid_returning_this:
+    guide: design
+    severity: avoid
+    references:
+      - https://dart.dev/guides/language/effective-dart/design#avoid-returning-this-from-methods-just-to-enable-a-fluent-interface
+  type_annotate_public_apis:
+    guide: design
+    severity: prefer
+    references:
+      - https://dart.dev/guides/language/effective-dart/design#prefer-type-annotating-public-fields-and-top-level-variables-if-the-type-isnt-obvious
+  prefer_typing_uninitialized_variables:
+    guide: design
+    severity: consider
+    references:
+      - https://dart.dev/guides/language/effective-dart/design#consider-type-annotating-private-fields-and-top-level-variables-if-the-type-isnt-obvious
+  omit_local_variable_types:
+    guide: design
+    severity: avoid
+    references:
+      - https://dart.dev/guides/language/effective-dart/design#avoid-type-annotating-initialized-local-variables
+  avoid_types_on_closure_parameters:
+    guide: design
+    severity: avoid
+    references:
+      - https://dart.dev/guides/language/effective-dart/design#avoid-annotating-inferred-parameter-types-on-function-expressions
+  avoid_return_types_on_setters:
+    guide: design
+    severity: don't
+    references:
+      - https://dart.dev/guides/language/effective-dart/design#dont-specify-a-return-type-for-a-setter
+  prefer_generic_function_type_aliases:
+    guide: design
+    severity: don't
+    references:
+      - https://dart.dev/guides/language/effective-dart/design#dont-use-the-legacy-typedef-syntax
+  avoid_private_typedef_functions:
+    guide: design
+    severity: prefer
+    references:
+      - https://dart.dev/guides/language/effective-dart/design#prefer-inline-function-types-over-typedefs
+  use_function_type_syntax_for_parameters:
+    guide: design
+    severity: consider
+    references:
+      - https://dart.dev/guides/language/effective-dart/design#consider-using-function-type-syntax-for-parameters
+  avoid_positional_boolean_parameters:
+    guide: design
+    severity: avoid
+    references:
+      - https://dart.dev/guides/language/effective-dart/design#avoid-positional-boolean-parameters
+  hash_and_equals:
+    guide: design
+    severity: do
+    references:
+      - https://dart.dev/guides/language/effective-dart/design#do-override-hashcode-if-you-override-
+  prefer_final_fields:
+    guide: design
+    severity: prefer
+    references:
+      - https://dart.dev/guides/language/effective-dart/design#prefer-making-fields-and-top-level-variables-final
+  use_to_and_as_if_applicable:
+    guide: design
+    severity: prefer
+    references:
+      - https://dart.dev/guides/language/effective-dart/design#prefer-naming-a-method-to___-if-it-copies-the-objects-state-to-a-new-object
+      - https://dart.dev/guides/language/effective-dart/design#prefer-naming-a-method-as___-if-it-returns-a-different-representation-backed-by-the-original-object

--- a/lib/metadata.1.3.0.yaml
+++ b/lib/metadata.1.3.0.yaml
@@ -1,0 +1,56 @@
+# effective_dart version 1.3.0
+effective_dart:
+  camel_case_types:
+    guide: style
+    severity: do
+    references:
+      - https://dart.dev/guides/language/effective-dart/style#do-name-types-using-uppercamelcase
+  camel_case_extensions:
+    guide: style
+    severity: do
+    references:
+      - https://dart.dev/guides/language/effective-dart/style#do-name-extensions-using-uppercamelcase
+  library_names:
+    guide: style
+    severity: do
+    references:
+      - https://dart.dev/guides/language/effective-dart/style#do-name-libraries-and-source-files-using-lowercase_with_underscores
+  file_names:
+    guide: style
+    severity: do
+    references:
+      - https://dart.dev/guides/language/effective-dart/style#do-name-libraries-and-source-files-using-lowercase_with_underscores
+  library_prefixes:
+    guide: style
+    severity: do
+    references:
+      - https://dart.dev/guides/language/effective-dart/style#do-name-import-prefixes-using-lowercase_with_underscores
+  non_constant_identifier_names:
+    guide: style
+    severity: do
+    references:
+      - https://dart.dev/guides/language/effective-dart/style#do-name-other-identifiers-using-lowercamelcase
+  constant_identifier_names:
+    guide: style
+    severity: prefer
+    references:
+      - https://dart.dev/guides/language/effective-dart/style#prefer-using-lowercamelcase-for-constant-names
+  directives_ordering:
+    guide: style
+    severity: do
+    references:
+      - https://dart.dev/guides/language/effective-dart/style#do-place-dart-imports-before-other-imports
+      - https://dart.dev/guides/language/effective-dart/style#do-place-package-imports-before-relative-imports
+      - https://dart.dev/guides/language/effective-dart/style#prefer-placing-third-party-package-imports-before-other-imports
+      - https://dart.dev/guides/language/effective-dart/style#do-specify-exports-in-a-separate-section-after-all-imports
+      - https://dart.dev/guides/language/effective-dart/style#do-sort-sections-alphabetically
+  lines_longer_than_80_chars:
+    guide: style
+    severity: avoid
+    references:
+      - https://dart.dev/guides/language/effective-dart/style#avoid-lines-longer-than-80-characters
+  curly_braces_in_flow_control_structures:
+    guide: style
+    severity: do
+    references:
+      - https://dart.dev/guides/language/effective-dart/style#do-use-curly-braces-for-all-flow-control-structures

--- a/lib/metadata.yaml
+++ b/lib/metadata.yaml
@@ -1,0 +1,1 @@
+include: package:effective_dart/metadata.1.3.0.yaml

--- a/lib/src/rules/database/design.dart
+++ b/lib/src/rules/database/design.dart
@@ -1,0 +1,183 @@
+import '../guide.dart';
+import '../lint_rule.dart';
+import '../severity.dart';
+
+///
+List<LintRule> rules = [
+  LintRule(
+    name: 'use_to_and_as_if_applicable',
+    severity: Severity.prefer,
+    guide: Guide.design,
+    references: [
+      // ignore: lines_longer_than_80_chars
+      'prefer-naming-a-method-to___-if-it-copies-the-objects-state-to-a-new-object',
+      // ignore: lines_longer_than_80_chars
+      'prefer-naming-a-method-as___-if-it-returns-a-different-representation-backed-by-the-original-object',
+    ],
+  ),
+  LintRule(
+    name: 'one_member_abstracts',
+    severity: Severity.avoid,
+    guide: Guide.design,
+    references: [
+      // ignore: lines_longer_than_80_chars
+      'avoid-defining-a-one-member-abstract-class-when-a-simple-function-will-do',
+    ],
+  ),
+  LintRule(
+    name: 'avoid_classes_with_only_static_members',
+    severity: Severity.avoid,
+    guide: Guide.design,
+    references: [
+      'avoid-defining-a-class-that-contains-only-static-members',
+    ],
+  ),
+  LintRule(
+    name: 'prefer_mixin',
+    severity: Severity.doit,
+    guide: Guide.design,
+    references: [
+      'do-use-mixin-to-define-a-mixin-type',
+      'avoid-mixing-in-a-class-that-isnt-intended-to-be-a-mixin',
+    ],
+  ),
+  LintRule(
+    name: 'prefer_final_fields',
+    severity: Severity.prefer,
+    guide: Guide.design,
+    references: [
+      'prefer-making-fields-and-top-level-variables-final',
+    ],
+  ),
+  LintRule(
+    name: 'use_setters_to_change_properties',
+    severity: Severity.doit,
+    guide: Guide.design,
+    references: [
+      'do-use-setters-for-operations-that-conceptually-change-properties',
+    ],
+  ),
+  LintRule(
+    name: 'avoid_setters_without_getters',
+    severity: Severity.dont,
+    guide: Guide.design,
+    references: [
+      'dont-define-a-setter-without-a-corresponding-getter',
+    ],
+  ),
+  LintRule(
+    name: 'avoid_returning_null',
+    severity: Severity.avoid,
+    guide: Guide.design,
+    references: [
+      // ignore: lines_longer_than_80_chars
+      'avoid-returning-null-from-members-whose-return-type-is-bool-double-int-or-num',
+    ],
+  ),
+  LintRule(
+    name: 'avoid_returning_this',
+    severity: Severity.avoid,
+    guide: Guide.design,
+    references: [
+      'avoid-returning-this-from-methods-just-to-enable-a-fluent-interface',
+    ],
+  ),
+  LintRule(
+    name: 'type_annotate_public_apis',
+    severity: Severity.prefer,
+    guide: Guide.design,
+    references: [
+      // ignore: lines_longer_than_80_chars
+      'prefer-type-annotating-public-fields-and-top-level-variables-if-the-type-isnt-obvious',
+    ],
+  ),
+  LintRule(
+    name: 'prefer_typing_uninitialized_variables',
+    severity: Severity.consider,
+    guide: Guide.design,
+    references: [
+      // ignore: lines_longer_than_80_chars
+      'consider-type-annotating-private-fields-and-top-level-variables-if-the-type-isnt-obvious',
+    ],
+  ),
+  LintRule(
+    name: 'omit_local_variable_types',
+    severity: Severity.avoid,
+    guide: Guide.design,
+    references: [
+      'avoid-type-annotating-initialized-local-variables',
+    ],
+  ),
+  LintRule(
+    name: 'avoid_types_on_closure_parameters',
+    severity: Severity.avoid,
+    guide: Guide.design,
+    references: [
+      'avoid-annotating-inferred-parameter-types-on-function-expressions',
+    ],
+  ),
+  LintRule(
+    name: 'avoid_return_types_on_setters',
+    severity: Severity.dont,
+    guide: Guide.design,
+    references: [
+      'dont-specify-a-return-type-for-a-setter',
+    ],
+  ),
+  LintRule(
+    name: 'prefer_generic_function_type_aliases',
+    severity: Severity.dont,
+    guide: Guide.design,
+    references: [
+      'dont-use-the-legacy-typedef-syntax',
+    ],
+  ),
+  LintRule(
+    name: 'avoid_private_typedef_functions',
+    severity: Severity.prefer,
+    guide: Guide.design,
+    references: [
+      'prefer-inline-function-types-over-typedefs',
+    ],
+  ),
+  LintRule(
+    name: 'use_function_type_syntax_for_parameters',
+    severity: Severity.consider,
+    guide: Guide.design,
+    references: [
+      'consider-using-function-type-syntax-for-parameters',
+    ],
+  ),
+  LintRule(
+    name: 'avoid_positional_boolean_parameters',
+    severity: Severity.avoid,
+    guide: Guide.design,
+    references: [
+      'avoid-positional-boolean-parameters',
+    ],
+  ),
+  LintRule(
+    name: 'hash_and_equals',
+    severity: Severity.doit,
+    guide: Guide.design,
+    references: [
+      'do-override-hashcode-if-you-override-',
+    ],
+  ),
+  LintRule(
+    name: 'avoid_equals_and_hash_code_on_mutable_classes',
+    severity: Severity.avoid,
+    guide: Guide.design,
+    references: [
+      'avoid-defining-custom-equality-for-mutable-classes',
+    ],
+  ),
+  LintRule(
+    name: 'avoid_null_checks_in_equality_operators',
+    severity: Severity.dont,
+    guide: Guide.design,
+    references: [
+      'dont-check-for-null-in-custom--operators',
+    ],
+  ),
+];

--- a/lib/src/rules/database/documentation.dart
+++ b/lib/src/rules/database/documentation.dart
@@ -1,0 +1,42 @@
+import '../guide.dart';
+import '../lint_rule.dart';
+import '../severity.dart';
+
+///
+List<LintRule> rules = [
+  LintRule(
+    name: 'slash_for_doc_comments',
+    severity: Severity.doit,
+    guide: Guide.documentation,
+    references: [
+      'do-use--doc-comments-to-document-members-and-types',
+    ],
+  ),
+  LintRule(
+    name: 'package_api_docs',
+    severity: Severity.prefer,
+    guide: Guide.documentation,
+    references: [
+      'prefer-writing-doc-comments-for-public-apis',
+    ],
+  ),
+  LintRule(
+    name: 'public_member_api_docs',
+    severity: Severity.prefer,
+    guide: Guide.documentation,
+    references: [
+      'prefer-writing-doc-comments-for-public-apis',
+    ],
+  ),
+  LintRule(
+    name: 'comment_references',
+    severity: Severity.doit,
+    guide: Guide.documentation,
+    references: [
+      'do-use-square-brackets-in-doc-comments-to-refer-to-in-scope-identifiers',
+    ],
+    disabled: true,
+    disabledReason:
+        'Unused because https://github.com/dart-lang/sdk/issues/36974',
+  ),
+];

--- a/lib/src/rules/database/style.dart
+++ b/lib/src/rules/database/style.dart
@@ -1,0 +1,91 @@
+import '../guide.dart';
+import '../lint_rule.dart';
+import '../severity.dart';
+
+///
+List<LintRule> rules = [
+  LintRule(
+    name: 'camel_case_types',
+    severity: Severity.doit,
+    guide: Guide.style,
+    references: [
+      'do-name-types-using-uppercamelcase',
+    ],
+  ),
+  LintRule(
+    name: 'camel_case_extensions',
+    severity: Severity.doit,
+    guide: Guide.style,
+    references: [
+      'do-name-extensions-using-uppercamelcase',
+    ],
+  ),
+  LintRule(
+    name: 'library_names',
+    severity: Severity.doit,
+    guide: Guide.style,
+    references: [
+      'do-name-libraries-and-source-files-using-lowercase_with_underscores',
+    ],
+  ),
+  LintRule(
+    name: 'file_names',
+    severity: Severity.doit,
+    guide: Guide.style,
+    references: [
+      'do-name-libraries-and-source-files-using-lowercase_with_underscores',
+    ],
+  ),
+  LintRule(
+    name: 'library_prefixes',
+    severity: Severity.doit,
+    guide: Guide.style,
+    references: [
+      'do-name-import-prefixes-using-lowercase_with_underscores',
+    ],
+  ),
+  LintRule(
+    name: 'non_constant_identifier_names',
+    severity: Severity.doit,
+    guide: Guide.style,
+    references: [
+      'do-name-other-identifiers-using-lowercamelcase',
+    ],
+  ),
+  LintRule(
+    name: 'constant_identifier_names',
+    severity: Severity.prefer,
+    guide: Guide.style,
+    references: [
+      'prefer-using-lowercamelcase-for-constant-names',
+    ],
+  ),
+  LintRule(
+    name: 'directives_ordering',
+    severity: Severity.doit,
+    guide: Guide.style,
+    references: [
+      'do-place-dart-imports-before-other-imports',
+      'do-place-package-imports-before-relative-imports',
+      'prefer-placing-third-party-package-imports-before-other-imports',
+      'do-specify-exports-in-a-separate-section-after-all-imports',
+      'do-sort-sections-alphabetically',
+    ],
+  ),
+  LintRule(
+    name: 'lines_longer_than_80_chars',
+    severity: Severity.avoid,
+    guide: Guide.style,
+    references: [
+      'avoid-lines-longer-than-80-characters',
+    ],
+  ),
+  LintRule(
+    name: 'curly_braces_in_flow_control_structures',
+    severity: Severity.doit,
+    guide: Guide.style,
+    references: [
+      'do-use-curly-braces-for-all-flow-control-structures',
+    ],
+  ),
+];

--- a/lib/src/rules/database/usage.dart
+++ b/lib/src/rules/database/usage.dart
@@ -1,0 +1,213 @@
+import '../guide.dart';
+import '../lint_rule.dart';
+import '../severity.dart';
+
+///
+List<LintRule> rules = [
+  LintRule(
+    name: 'implementation_imports',
+    severity: Severity.dont,
+    guide: Guide.usage,
+    references: [
+      // ignore: lines_longer_than_80_chars
+      'dont-import-libraries-that-are-inside-the-src-directory-of-another-package',
+    ],
+  ),
+  LintRule(
+    name: 'avoid_relative_lib_imports',
+    severity: Severity.prefer,
+    guide: Guide.usage,
+    references: [
+      // ignore: lines_longer_than_80_chars
+      'prefer-relative-paths-when-importing-libraries-within-your-own-packages-lib-directory',
+    ],
+  ),
+  LintRule(
+    name: 'prefer_relative_imports',
+    severity: Severity.prefer,
+    guide: Guide.usage,
+    references: [
+      // ignore: lines_longer_than_80_chars
+      'prefer-relative-paths-when-importing-libraries-within-your-own-packages-lib-directory',
+    ],
+  ),
+  LintRule(
+    name: 'prefer_adjacent_string_concatenation',
+    severity: Severity.doit,
+    guide: Guide.usage,
+    references: [
+      'do-use-adjacent-strings-to-concatenate-string-literals',
+    ],
+  ),
+  LintRule(
+    name: 'prefer_interpolation_to_compose_strings',
+    severity: Severity.prefer,
+    guide: Guide.usage,
+    references: [
+      'prefer-using-interpolation-to-compose-strings-and-values',
+    ],
+  ),
+  LintRule(
+    name: 'unnecessary_brace_in_string_interps',
+    severity: Severity.avoid,
+    guide: Guide.usage,
+    references: [
+      'avoid-using-curly-braces-in-interpolation-when-not-needed',
+    ],
+  ),
+  LintRule(
+    name: 'prefer_collection_literals',
+    severity: Severity.doit,
+    guide: Guide.usage,
+    references: [
+      'do-use-collection-literals-when-possible',
+    ],
+  ),
+  LintRule(
+    name: 'avoid_function_literals_in_foreach_calls',
+    severity: Severity.avoid,
+    guide: Guide.usage,
+    references: [
+      'avoid-using-iterableforeach-with-a-function-literal',
+    ],
+  ),
+  LintRule(
+    name: 'prefer_iterable_whereType',
+    severity: Severity.doit,
+    guide: Guide.usage,
+    references: [
+      'do-use-wheretype-to-filter-a-collection-by-type',
+    ],
+  ),
+  LintRule(
+    name: 'prefer_function_declarations_over_variables',
+    severity: Severity.doit,
+    guide: Guide.usage,
+    references: [
+      'do-use-a-function-declaration-to-bind-a-function-to-a-name',
+    ],
+  ),
+  LintRule(
+    name: 'unnecessary_lambdas',
+    severity: Severity.dont,
+    guide: Guide.usage,
+    references: [
+      'dont-create-a-lambda-when-a-tear-off-will-do',
+    ],
+  ),
+  LintRule(
+    name: 'prefer_equal_for_default_values',
+    severity: Severity.doit,
+    guide: Guide.usage,
+    references: [
+      'do-use--to-separate-a-named-parameter-from-its-default-value',
+    ],
+  ),
+  LintRule(
+    name: 'avoid_init_to_null',
+    severity: Severity.dont,
+    guide: Guide.usage,
+    references: [
+      'dont-use-an-explicit-default-value-of-null',
+    ],
+  ),
+  LintRule(
+    name: 'unnecessary_getters_setters',
+    severity: Severity.dont,
+    guide: Guide.usage,
+    references: [
+      'dont-wrap-a-field-in-a-getter-and-setter-unnecessarily',
+    ],
+  ),
+  LintRule(
+    name: 'unnecessary_getters',
+    severity: Severity.prefer,
+    guide: Guide.usage,
+    references: [
+      'prefer-using-a-final-field-to-make-a-read-only-property',
+    ],
+    disabled: true,
+    disabledReason:
+        'Disabled pending fix: https://github.com/dart-lang/linter/issues/23',
+  ),
+  LintRule(
+    name: 'prefer_expression_function_bodies',
+    severity: Severity.consider,
+    guide: Guide.usage,
+    references: [
+      'consider-using--for-simple-members',
+    ],
+  ),
+  LintRule(
+    name: 'unnecessary_this',
+    severity: Severity.dont,
+    guide: Guide.usage,
+    references: [
+      'dont-use-this-when-not-needed-to-avoid-shadowing',
+    ],
+  ),
+  LintRule(
+    name: 'prefer_initializing_formals',
+    severity: Severity.doit,
+    guide: Guide.usage,
+    references: [
+      'do-use-initializing-formals-when-possible',
+    ],
+  ),
+  LintRule(
+    name: 'type_init_formals',
+    severity: Severity.dont,
+    guide: Guide.usage,
+    references: [
+      'dont-type-annotate-initializing-formals',
+    ],
+  ),
+  LintRule(
+    name: 'empty_constructor_bodies',
+    severity: Severity.doit,
+    guide: Guide.usage,
+    references: [
+      'do-use--instead-of--for-empty-constructor-bodies',
+    ],
+  ),
+  LintRule(
+    name: 'unnecessary_new',
+    severity: Severity.dont,
+    guide: Guide.usage,
+    references: [
+      'dont-use-new',
+    ],
+  ),
+  LintRule(
+    name: 'unnecessary_const',
+    severity: Severity.dont,
+    guide: Guide.usage,
+    references: [
+      'dont-use-const-redundantly',
+    ],
+  ),
+  LintRule(
+    name: 'avoid_catches_without_on_clauses',
+    severity: Severity.avoid,
+    guide: Guide.usage,
+    references: [
+      'avoid-catches-without-on-clauses',
+    ],
+  ),
+  LintRule(
+    name: 'avoid_catching_errors',
+    severity: Severity.dont,
+    guide: Guide.usage,
+    references: [
+      'dont-explicitly-catch-error-or-types-that-implement-it',
+    ],
+  ),
+  LintRule(
+    name: 'use_rethrow_when_possible',
+    severity: Severity.doit,
+    guide: Guide.usage,
+    references: [
+      'do-use-rethrow-to-rethrow-a-caught-exception',
+    ],
+  ),
+];

--- a/lib/src/rules/generator/analysis_options_generator.dart
+++ b/lib/src/rules/generator/analysis_options_generator.dart
@@ -26,8 +26,10 @@ linter:
   rules:
 ''');
 
+    // Sort rules by guide.
     rules.sort((a, b) => a.guide.index.compareTo(b.guide.index));
     var currentGuide = rules.first.guide;
+
     _buffer.writeln('    # ${guideToString(currentGuide).toUpperCase()}');
     for (final rule in rules) {
       if (rule.guide != currentGuide) {
@@ -37,8 +39,11 @@ linter:
         _buffer.writeln('    # ${guideToString(currentGuide).toUpperCase()}');
       }
 
-      _buffer
-          .writeln('    - ${rule.name} # ${severityToString(rule.severity)}');
+      _buffer.write(
+          // ignore: lines_longer_than_80_chars
+          '    ${(rule.disabled || rule.severity == Severity.consider) ? '#' : ''}');
+      _buffer.write('- ${rule.name} # ${severityToString(rule.severity)}');
+      _buffer.writeln('${rule.disabled ? ' # ${rule.disabledReason}' : ''}');
     }
 
     return _buffer.toString();

--- a/lib/src/rules/generator/analysis_options_generator.dart
+++ b/lib/src/rules/generator/analysis_options_generator.dart
@@ -1,0 +1,46 @@
+import 'package:meta/meta.dart';
+
+import '../guide.dart';
+import '../lint_rule.dart';
+import '../severity.dart';
+import 'generator.dart';
+
+///
+class AnalysisOptionsGenerator extends Generator {
+  ///
+  final _buffer = StringBuffer();
+
+  ///
+  AnalysisOptionsGenerator({
+    @required String version,
+    @required List<LintRule> rules,
+  }) : super(version: version, rules: rules);
+
+  ///
+  @override
+  String generate() {
+    _buffer.clear();
+    _buffer.write('''
+# effective_dart version $version
+linter:
+  rules:
+''');
+
+    rules.sort((a, b) => a.guide.index.compareTo(b.guide.index));
+    var currentGuide = rules.first.guide;
+    _buffer.writeln('    # ${guideToString(currentGuide).toUpperCase()}');
+    for (final rule in rules) {
+      if (rule.guide != currentGuide) {
+        currentGuide = rule.guide;
+
+        _buffer.writeln();
+        _buffer.writeln('    # ${guideToString(currentGuide).toUpperCase()}');
+      }
+
+      _buffer
+          .writeln('    - ${rule.name} # ${severityToString(rule.severity)}');
+    }
+
+    return _buffer.toString();
+  }
+}

--- a/lib/src/rules/generator/generator.dart
+++ b/lib/src/rules/generator/generator.dart
@@ -1,0 +1,22 @@
+import 'package:meta/meta.dart';
+
+import '../lint_rule.dart';
+
+///
+@immutable
+abstract class Generator {
+  ///
+  final String version;
+
+  ///
+  final List<LintRule> rules;
+
+  ///
+  Generator({
+    @required this.version,
+    @required this.rules,
+  });
+
+  ///
+  String generate();
+}

--- a/lib/src/rules/generator/metadata_generator.dart
+++ b/lib/src/rules/generator/metadata_generator.dart
@@ -1,0 +1,41 @@
+import 'package:meta/meta.dart';
+
+import '../guide.dart';
+import '../lint_rule.dart';
+import '../severity.dart';
+import 'generator.dart';
+
+///
+class MetadataGenerator extends Generator {
+  ///
+  final _buffer = StringBuffer();
+
+  ///
+  MetadataGenerator({
+    @required String version,
+    @required List<LintRule> rules,
+  }) : super(version: version, rules: rules);
+
+  ///
+  @override
+  String generate() {
+    _buffer.write('''
+# effective_dart version $version
+effective_dart:
+''');
+
+    for (final rule in rules) {
+      _buffer.writeln('  ${rule.name}:');
+      _buffer.writeln('    guide: ${guideToString(rule.guide)}');
+      _buffer.writeln('    severity: ${severityToString(rule.severity)}');
+      _buffer.writeln('    references:');
+
+      for (final reference in rule.references) {
+        _buffer
+            .writeln('      - ${referenceInGuideToUrl(rule.guide, reference)}');
+      }
+    }
+
+    return _buffer.toString();
+  }
+}

--- a/lib/src/rules/generator/metadata_generator.dart
+++ b/lib/src/rules/generator/metadata_generator.dart
@@ -34,6 +34,11 @@ effective_dart:
         _buffer
             .writeln('      - ${referenceInGuideToUrl(rule.guide, reference)}');
       }
+
+      if (rule.disabled) {
+        _buffer.writeln('    disabled: true');
+        _buffer.writeln('    disabled_reason: "${rule.disabledReason}"');
+      }
     }
 
     return _buffer.toString();

--- a/lib/src/rules/guide.dart
+++ b/lib/src/rules/guide.dart
@@ -1,0 +1,34 @@
+///
+enum Guide {
+  ///
+  style,
+
+  ///
+  documentation,
+
+  ///
+  usage,
+
+  ///
+  design,
+}
+
+///
+// ignore: missing_return
+String guideToString(Guide guide) {
+  switch (guide) {
+    case Guide.style:
+      return 'style';
+    case Guide.documentation:
+      return 'documentation';
+    case Guide.usage:
+      return 'usage';
+    case Guide.design:
+      return 'design';
+  }
+}
+
+///
+String referenceInGuideToUrl(Guide guide, String hash) {
+  return 'https://dart.dev/guides/language/effective-dart/${guideToString(guide)}#$hash';
+}

--- a/lib/src/rules/lint_rule.dart
+++ b/lib/src/rules/lint_rule.dart
@@ -1,0 +1,33 @@
+import 'package:meta/meta.dart';
+
+import 'guide.dart';
+import 'severity.dart';
+
+///
+@immutable
+class LintRule {
+  /// Contains name of the lint as used in the linter.
+  /// For example `public_member_api_docs`.
+  final String name;
+
+  ///
+  final Severity severity;
+
+  ///
+  final Guide guide;
+
+  /// URL after hash (#)
+  ///
+  /// For example, for url
+  /// https://dart.dev/guides/language/effective-dart/style#do-name-types-using-uppercamelcase
+  /// use only -> do-name-types-using-uppercamelcase
+  final List<String> references;
+
+  ///
+  LintRule({
+    @required this.name,
+    @required this.severity,
+    @required this.guide,
+    @required this.references,
+  });
+}

--- a/lib/src/rules/lint_rule.dart
+++ b/lib/src/rules/lint_rule.dart
@@ -16,11 +16,21 @@ class LintRule {
   ///
   final Guide guide;
 
+  /// Determines if the rule will be used as "active" or not.
+  ///
+  /// For example when the rule is considered as broken,
+  /// make the value false.
+  final bool disabled;
+
+  /// If [disabled] is false,
+  /// this message is *required* and will be used in appropriate places.
+  final String disabledReason;
+
   /// URL after hash (#)
   ///
   /// For example, for url
-  /// https://dart.dev/guides/language/effective-dart/style#do-name-types-using-uppercamelcase
-  /// use only -> do-name-types-using-uppercamelcase
+  /// 'https://dart.dev/guides/language/effective-dart/style#do-name-types-using-uppercamelcase'
+  /// use only 'do-name-types-using-uppercamelcase'
   final List<String> references;
 
   ///
@@ -29,5 +39,7 @@ class LintRule {
     @required this.severity,
     @required this.guide,
     @required this.references,
-  });
+    this.disabled = false,
+    this.disabledReason = "",
+  }) : assert(disabled ? disabledReason != null : true);
 }

--- a/lib/src/rules/rules.dart
+++ b/lib/src/rules/rules.dart
@@ -1,0 +1,103 @@
+import 'guide.dart';
+import 'lint_rule.dart';
+import 'severity.dart';
+
+///
+List<LintRule> allRules = []
+  ..addAll(_styleRules)
+  ..addAll(_documentationRules)
+  ..addAll(_usageRules)
+  ..addAll(_designRules);
+
+List<LintRule> _styleRules = [
+  LintRule(
+    name: 'camel_case_types',
+    severity: Severity.doit,
+    guide: Guide.style,
+    references: [
+      'do-name-types-using-uppercamelcase',
+    ],
+  ),
+  LintRule(
+    name: 'camel_case_extensions',
+    severity: Severity.doit,
+    guide: Guide.style,
+    references: [
+      'do-name-extensions-using-uppercamelcase',
+    ],
+  ),
+  LintRule(
+    name: 'library_names',
+    severity: Severity.doit,
+    guide: Guide.style,
+    references: [
+      'do-name-libraries-and-source-files-using-lowercase_with_underscores',
+    ],
+  ),
+  LintRule(
+    name: 'file_names',
+    severity: Severity.doit,
+    guide: Guide.style,
+    references: [
+      'do-name-libraries-and-source-files-using-lowercase_with_underscores',
+    ],
+  ),
+  LintRule(
+    name: 'library_prefixes',
+    severity: Severity.doit,
+    guide: Guide.style,
+    references: [
+      'do-name-import-prefixes-using-lowercase_with_underscores',
+    ],
+  ),
+  LintRule(
+    name: 'non_constant_identifier_names',
+    severity: Severity.doit,
+    guide: Guide.style,
+    references: [
+      'do-name-other-identifiers-using-lowercamelcase',
+    ],
+  ),
+  LintRule(
+    name: 'constant_identifier_names',
+    severity: Severity.prefer,
+    guide: Guide.style,
+    references: [
+      'prefer-using-lowercamelcase-for-constant-names',
+    ],
+  ),
+  LintRule(
+    name: 'directives_ordering',
+    severity: Severity.doit,
+    guide: Guide.style,
+    references: [
+      'do-place-dart-imports-before-other-imports',
+      'do-place-package-imports-before-relative-imports',
+      'prefer-placing-third-party-package-imports-before-other-imports',
+      'do-specify-exports-in-a-separate-section-after-all-imports',
+      'do-sort-sections-alphabetically',
+    ],
+  ),
+  LintRule(
+    name: 'lines_longer_than_80_chars',
+    severity: Severity.avoid,
+    guide: Guide.style,
+    references: [
+      'avoid-lines-longer-than-80-characters',
+    ],
+  ),
+  LintRule(
+    name: 'curly_braces_in_flow_control_structures',
+    severity: Severity.doit,
+    guide: Guide.style,
+    references: [
+      'do-use-curly-braces-for-all-flow-control-structures',
+    ],
+  ),
+];
+
+List<LintRule> _documentationRules = [];
+
+List<LintRule> _usageRules = [];
+
+List<LintRule> _designRules = [];

--- a/lib/src/rules/rules.dart
+++ b/lib/src/rules/rules.dart
@@ -1,103 +1,12 @@
-import 'guide.dart';
+import 'database/design.dart' as design;
+import 'database/documentation.dart' as documentation;
+import 'database/style.dart' as style;
+import 'database/usage.dart' as usage;
 import 'lint_rule.dart';
-import 'severity.dart';
 
 ///
 List<LintRule> allRules = []
-  ..addAll(_styleRules)
-  ..addAll(_documentationRules)
-  ..addAll(_usageRules)
-  ..addAll(_designRules);
-
-List<LintRule> _styleRules = [
-  LintRule(
-    name: 'camel_case_types',
-    severity: Severity.doit,
-    guide: Guide.style,
-    references: [
-      'do-name-types-using-uppercamelcase',
-    ],
-  ),
-  LintRule(
-    name: 'camel_case_extensions',
-    severity: Severity.doit,
-    guide: Guide.style,
-    references: [
-      'do-name-extensions-using-uppercamelcase',
-    ],
-  ),
-  LintRule(
-    name: 'library_names',
-    severity: Severity.doit,
-    guide: Guide.style,
-    references: [
-      'do-name-libraries-and-source-files-using-lowercase_with_underscores',
-    ],
-  ),
-  LintRule(
-    name: 'file_names',
-    severity: Severity.doit,
-    guide: Guide.style,
-    references: [
-      'do-name-libraries-and-source-files-using-lowercase_with_underscores',
-    ],
-  ),
-  LintRule(
-    name: 'library_prefixes',
-    severity: Severity.doit,
-    guide: Guide.style,
-    references: [
-      'do-name-import-prefixes-using-lowercase_with_underscores',
-    ],
-  ),
-  LintRule(
-    name: 'non_constant_identifier_names',
-    severity: Severity.doit,
-    guide: Guide.style,
-    references: [
-      'do-name-other-identifiers-using-lowercamelcase',
-    ],
-  ),
-  LintRule(
-    name: 'constant_identifier_names',
-    severity: Severity.prefer,
-    guide: Guide.style,
-    references: [
-      'prefer-using-lowercamelcase-for-constant-names',
-    ],
-  ),
-  LintRule(
-    name: 'directives_ordering',
-    severity: Severity.doit,
-    guide: Guide.style,
-    references: [
-      'do-place-dart-imports-before-other-imports',
-      'do-place-package-imports-before-relative-imports',
-      'prefer-placing-third-party-package-imports-before-other-imports',
-      'do-specify-exports-in-a-separate-section-after-all-imports',
-      'do-sort-sections-alphabetically',
-    ],
-  ),
-  LintRule(
-    name: 'lines_longer_than_80_chars',
-    severity: Severity.avoid,
-    guide: Guide.style,
-    references: [
-      'avoid-lines-longer-than-80-characters',
-    ],
-  ),
-  LintRule(
-    name: 'curly_braces_in_flow_control_structures',
-    severity: Severity.doit,
-    guide: Guide.style,
-    references: [
-      'do-use-curly-braces-for-all-flow-control-structures',
-    ],
-  ),
-];
-
-List<LintRule> _documentationRules = [];
-
-List<LintRule> _usageRules = [];
-
-List<LintRule> _designRules = [];
+  ..addAll(style.rules)
+  ..addAll(documentation.rules)
+  ..addAll(usage.rules)
+  ..addAll(design.rules);

--- a/lib/src/rules/severity.dart
+++ b/lib/src/rules/severity.dart
@@ -1,0 +1,34 @@
+///
+enum Severity {
+  ///
+  doit,
+
+  ///
+  dont,
+
+  ///
+  prefer,
+
+  ///
+  avoid,
+
+  ///
+  consider,
+}
+
+///
+// ignore: missing_return
+String severityToString(Severity severity) {
+  switch (severity) {
+    case Severity.doit:
+      return 'do';
+    case Severity.dont:
+      return "don't";
+    case Severity.prefer:
+      return 'prefer';
+    case Severity.avoid:
+      return 'avoid';
+    case Severity.consider:
+      return 'consider';
+  }
+}

--- a/lib/src/rules/severity.dart
+++ b/lib/src/rules/severity.dart
@@ -32,3 +32,20 @@ String severityToString(Severity severity) {
       return 'consider';
   }
 }
+
+///
+// ignore: missing_return
+String severityToAnalyzerError(Severity severity) {
+  switch (severity) {
+    case Severity.doit:
+      return 'error';
+    case Severity.dont:
+      return "error";
+    case Severity.prefer:
+      return 'warning';
+    case Severity.avoid:
+      return 'warning';
+    case Severity.consider:
+      return 'info';
+  }
+}

--- a/lib/src/rules/version.dart
+++ b/lib/src/rules/version.dart
@@ -1,0 +1,2 @@
+/// Package version used to generate analysis options.
+const String version = '1.3.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,3 +8,6 @@ homepage: https://github.com/tenhobi/effective_dart
 
 environment:
   sdk: '>=2.0.0 <3.0.0'
+
+dependencies:
+  meta: ^1.1.8

--- a/tool/generate.dart
+++ b/tool/generate.dart
@@ -1,0 +1,7 @@
+import 'generate_analysis_options.dart';
+import 'generate_metadata.dart';
+
+void main() {
+  generateAnalysisOptions();
+  generateMetadata();
+}

--- a/tool/generate_analysis_options.dart
+++ b/tool/generate_analysis_options.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+
+import 'package:effective_dart/src/rules/generator/analysis_options_generator.dart';
+import 'package:effective_dart/src/rules/rules.dart';
+import 'package:effective_dart/src/rules/version.dart';
+
+void main() => generateAnalysisOptions();
+
+void generateAnalysisOptions() {
+  print('Generating metadata file.');
+  final generator = AnalysisOptionsGenerator(version: version, rules: allRules);
+  final file = File('lib/analysis_options.$version.yaml');
+  file.writeAsStringSync(generator.generate());
+  print('Done');
+}

--- a/tool/generate_analysis_options.dart
+++ b/tool/generate_analysis_options.dart
@@ -7,9 +7,19 @@ import 'package:effective_dart/src/rules/version.dart';
 void main() => generateAnalysisOptions();
 
 void generateAnalysisOptions() {
-  print('Generating metadata file.');
+  const fileName = 'analysis_options';
+  const filePath = 'lib/$fileName';
+  const fileExtension = 'yaml';
+
+  print('Generating analysis options file.');
   final generator = AnalysisOptionsGenerator(version: version, rules: allRules);
-  final file = File('lib/analysis_options.$version.yaml');
+  final file = File('$filePath.$version.$fileExtension');
   file.writeAsStringSync(generator.generate());
-  print('Done');
+
+  print('Updating base file.');
+  final baseFile = File('$filePath.$fileExtension');
+  baseFile.writeAsStringSync(
+      'include: package:effective_dart/$fileName.$version.$fileExtension');
+
+  print('Done.');
 }

--- a/tool/generate_metadata.dart
+++ b/tool/generate_metadata.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+
+import 'package:effective_dart/src/rules/generator/metadata_generator.dart';
+import 'package:effective_dart/src/rules/rules.dart';
+import 'package:effective_dart/src/rules/version.dart';
+
+void main() => generateMetadata();
+
+void generateMetadata() {
+  print('Generating metadata file.');
+  final generator = MetadataGenerator(version: version, rules: allRules);
+  final file = File('lib/metadata.$version.yaml');
+  file.writeAsStringSync(generator.generate());
+  print('Done.');
+}

--- a/tool/generate_metadata.dart
+++ b/tool/generate_metadata.dart
@@ -7,9 +7,19 @@ import 'package:effective_dart/src/rules/version.dart';
 void main() => generateMetadata();
 
 void generateMetadata() {
+  const fileName = 'metadata';
+  const filePath = 'lib/$fileName';
+  const fileExtension = 'yaml';
+
   print('Generating metadata file.');
   final generator = MetadataGenerator(version: version, rules: allRules);
-  final file = File('lib/metadata.$version.yaml');
+  final file = File('$filePath.$version.$fileExtension');
   file.writeAsStringSync(generator.generate());
+
+  print('Updating base file.');
+  final baseFile = File('$filePath.$fileExtension');
+  baseFile.writeAsStringSync(
+      'include: package:effective_dart/$fileName.$version.$fileExtension');
+
   print('Done.');
 }


### PR DESCRIPTION
Proposal of simple generators for 

- analysis options
- metadata (**new**) https://github.com/dart-lang/linter/issues/1934

For rules it creates also **metadata file** that other apps can process better (and with more information).

TODO:
- [x] generating linter rules
- [x] generating analyzer severity (#23)
- [x] generating metadata
- [x] CI: analyze, format