### PR TITLE
Improving Pub points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-This project adheres to [Semantic Versioning](http://semver.org).
+This project adheres to [Semantic Versioning](https://semver.org).
 
 ## 1.2.3
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **Be consistent. Be brief.**
 
 This package provides linter rules corresponding to the guidelines in
-*[Effective Dart][]*.
+_[Effective Dart][]_.
 You can easily see all enabled rules on the [Supported Lint Rules][] site.
 
 **Note**: This package is inspired by the [pedantic][] package,
@@ -53,10 +53,10 @@ Following lints are not enforced by this package:
 Following lints have been considered and will not be enforced by this package:
 
 - [`unnecessary_getters`](https://dart-lang.github.io/linter/lints/unnecessary_getters.html)
-has been [disabled](https://github.com/dart-lang/linter/issues/23)
+  has been [disabled](https://github.com/dart-lang/linter/issues/23)
 - [`comment_references`](https://dart-lang.github.io/linter/lints/comment_references.html)
-is way too restrictive and comment references are handled in different ways
-in tools ([see this issue](https://github.com/dart-lang/sdk/issues/36974))
+  is way too restrictive and comment references are handled in different ways
+  in tools ([see this issue](https://github.com/dart-lang/sdk/issues/36974))
 
 ## Suppressing Lints
 
@@ -67,7 +67,7 @@ We will go through examples of how to suppress
 lint rule.
 
 **Note**: this package provides linter rules corresponding to the guidelines
-in *[Effective Dart][]*.
+in _[Effective Dart][]_.
 That means we generally do not want to disable a rule in this package
 if it works properly.
 Yet, if you think some rule should be disabled by this package, open an issue.
@@ -110,7 +110,7 @@ linter:
 
 ## Badge
 
-Show the world you're following *Effective Dart* →
+Show the world you're following _Effective Dart_ →
 [![style: effective dart][badge]][badge_link]
 
 ```md
@@ -121,8 +121,8 @@ Show the world you're following *Effective Dart* →
 
 Licensed under the [MIT License](LICENSE).
 
-[Effective Dart]: https://dart.dev/guides/language/effective-dart
+[effective dart]: https://dart.dev/guides/language/effective-dart
 [pedantic]: https://github.com/dart-lang/pedantic
-[Supported Lint Rules]: http://dart-lang.github.io/linter/lints
+[supported lint rules]: https://dart-lang.github.io/linter/lints
 [badge]: https://img.shields.io/badge/style-effective_dart-40c4ff.svg
 [badge_link]: https://pub.dev/packages/effective_dart

--- a/example/example.md
+++ b/example/example.md
@@ -1,0 +1,23 @@
+# How to use the package
+
+To use the lints add a dev dependency in your `pubspec.yaml`:
+
+```yaml
+dev_dependencies:
+  effective_dart: ^1.2.0
+```
+
+Then add an include in your `analysis_options.yaml` file:
+
+```yaml
+include: package:effective_dart/analysis_options.yaml
+```
+
+Or, if you using e.g. continuous builds,
+they will likely fail whenever a new version of `package:effective_dart`
+is released.
+To avoid this, specify a version of `analysis_options.yaml`:
+
+```yaml
+include: package:effective_dart/analysis_options.1.2.0.yaml
+```

--- a/lib/effective_dart.dart
+++ b/lib/effective_dart.dart
@@ -1,3 +1,4 @@
 @Deprecated("Don't use this!")
-/// Just a dummy code to temporary fix an issue #12. 
+
+/// Just a dummy code to temporary fix an issue #12.
 void dummyCode() {}


### PR DESCRIPTION
According to pub.dev this package has 80/100. I like the package, but thought it didn't reflect well for effective_dart to have a less than perfect score. Most of them are silly stuff on the readme, and missing example file.

This should get the score to 110

Reference: https://pub.dev/packages/effective_dart/score